### PR TITLE
removed invalid escape character from message

### DIFF
--- a/Darkside/20201115.json
+++ b/Darkside/20201115.json
@@ -213,7 +213,7 @@
         },
         {
             "party": "Darkside",
-            "content": "File\n            \n\[redacted].txt\n8.81 kB",
+            "content": "File\n            \n[redacted].txt\n8.81 kB",
             "timestamp": "8 days  ago"
         },
         {


### PR DESCRIPTION
line 216 contained an escape character which invalidated the json file: 
"File\n            \n -> \ <- [redacted].txt\n8.81 kB",